### PR TITLE
Update Ch 07 - Regex Strip.py

### DIFF
--- a/Practice-Projects/Ch 07 - Regex Strip.py
+++ b/Practice-Projects/Ch 07 - Regex Strip.py
@@ -22,7 +22,7 @@ char_rm = input('What characters do you want to remove? (Press enter for whiteps
 # spaces are removed print out the length of the new string.
 def white_strip(string, remove):
     if remove != '':
-        strip_regex = re.compile(remove)
+        strip_regex = re.compile(fr'^{remove}+|{remove}+$')
         new_string = strip_regex.sub('', string)
         return new_string
     else:


### PR DESCRIPTION
Hi, 

I may be wrong but the function does not behave like the strip method of str type. In the strip method if an argument is provided the string it is called on is returned with the argument stripped only from the start or end of the string. The function above seems to work when no second argument is provided. When a second argument is provided it instead strips that argument from the string regardless of where in the string that argument is located. I may be wrong?

I adjusted line 25. I may be incorrect so please let me know if I am. I   have been learning a lot from the solutions you've posted to the chapter projects of this book. Thanks very much.